### PR TITLE
Permit user installed root certificates in Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/src/API/index.js
+++ b/src/API/index.js
@@ -40,7 +40,6 @@ export class API {
       baseURL: `${this.credentials.server}/index.php/apps/passwords`,
       timeout: 2 * 60 * 1000,
       headers: { 'OCS-APIRequest': 'true' },
-      rejectUnauthorized: false,
       auth
     })
 
@@ -90,7 +89,6 @@ export class API {
         baseURL: `${this.credentials.server}`,
         timeout: 10 * 1000,
         headers: { 'OCS-APIRequest': 'true' },
-        rejectUnauthorized: false,
         auth: {
           username: this.credentials.user,
           password: this.credentials.password,


### PR DESCRIPTION
- Add permission to use user installed root certificates to AndroidManifest.xml
- Remove not needed and not existing rejectUnauthorized options for axios