### PR TITLE
drop failing sha comparison / add python git module

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,6 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/tools/f-droid.Dockerfile
+++ b/tools/f-droid.Dockerfile
@@ -41,11 +41,13 @@ RUN mkdir -p $ANDROID_HOME \
     && yes | sdkmanager "platform-tools" "tools" "build-tools;28.0.3" "platforms;android-28"
 
 RUN wget "https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip" -O /opt/ndk.zip \
-    && echo "fd94d0be6017c6acbd193eb95e09cf4b6f61b834 /opt/ndk.zip" | sha1sum -c - \
     && cd /opt && unzip ndk.zip && rm ndk.zip
+
 
 RUN git clone https://gitlab.com/fdroid/fdroidserver.git /fdroidserver \
     && git clone https://gitlab.com/fdroid/fdroiddata.git /repo
+
+RUN apt-get install python3-git -y
 
 WORKDIR /repo
 ENTRYPOINT ["fdroid"]


### PR DESCRIPTION
relates to #65 
i want to help with fixing the f-droid build but i did not get very far with building the app.
I had to change some things to make the f-droid builder server actually run as you can see in my branch. I run `build-fdroi.sh` and get only so far
```:app:generateReleaseSources
:react-native-sensitive-info:generateReleaseSources
:react-native-sensitive-info:compileReleaseJavaWithJavac/repo/build/com.nextcloudpasswords/node_modules/react-native-sensitive-info/android/src/main/java/br/com/classapp/RNSensitiveInfo/RNSensitiveInfoModule.java:17: error: package androidx.annotation does not exist
import androidx.annotation.NonNull;
```

Given that i had to change some things i assume the files required for f-droid are not up to date. I would have assumed to reach at least the xsel error you mentioned here (https://gitlab.com/fdroid/fdroiddata/-/merge_requests/6453)

@daper i'd like to help. what am i missing here?